### PR TITLE
fixed "vagrant up" hanging during root-bootstrap.sh

### DIFF
--- a/vm/bin/root-bootstrap.sh
+++ b/vm/bin/root-bootstrap.sh
@@ -8,7 +8,7 @@ set -xe
 apt-get update
 
 KERNEL=$(uname -r)
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt-get install -y --no-install-recommends \
   autoconf \
   automake \


### PR DESCRIPTION
root-bootstrap.sh was hanging while setting up grub-pc package waiting for user input to confirm change of /etc/default/grub (modified and maintainers version essentially only differing in a trainling white space ;) ). Reason: noninteractive mode for dpkg ignored. sudo will use new env without the previously defined DEBIAN_FRONTEND var. Either use sudo in front of the command line (superfluous as running as root anyway) or remove sudo as in this tiny PR.

[p4-learning-vagrant-grub-pc-hanging.log](https://github.com/nsg-ethz/p4-learning/files/5658722/p4-learning-vagrant-grub-pc-hanging.log)
